### PR TITLE
Do not concat multiple values

### DIFF
--- a/lib/hyrax/ingest/fetcher/xml_file.rb
+++ b/lib/hyrax/ingest/fetcher/xml_file.rb
@@ -17,7 +17,7 @@ module Hyrax
 
         def fetch
           # TODO: log a warning in the event of empty results.
-          noko.xpath(xpath).text
+          noko.xpath(xpath).map(&:text)
         end
 
         private

--- a/spec/hyrax/ingest/fetcher/xml_file_spec.rb
+++ b/spec/hyrax/ingest/fetcher/xml_file_spec.rb
@@ -13,7 +13,7 @@ RSpec.describe Hyrax::Ingest::Fetcher::XMLFile do
       let(:fetcher_2) { described_class.new(sip, options) }
 
       it 'returns the value from the XML pointed to by the xpath' do
-        expect(fetcher_1.fetch).to eq '"Brain" Cam 1 Tape 1'
+        expect(fetcher_1.fetch).to eq ['"Brain" Cam 1 Tape 1']
       end
 
       it 'can fetch same metadata from the same SIP using 2 different fetcher objects' do
@@ -26,7 +26,7 @@ RSpec.describe Hyrax::Ingest::Fetcher::XMLFile do
       let(:fetcher) { described_class.new(sip, options) }
 
       it 'finds the file within the sip' do
-        expect(fetcher.fetch).to eq '"Brain" Cam 1 Tape 1'
+        expect(fetcher.fetch).to eq ['"Brain" Cam 1 Tape 1']
       end
     end
   end


### PR DESCRIPTION
When fetching from an XML file results in multiple values, do not concatenate them
together. Instead, just use the first.