### PR TITLE
Adds suppport for ingesting Preservation Events

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -46,3 +46,6 @@ else
   end
 end
 # END ENGINE_CART BLOCK
+
+# TODO: Need to pull from github until gem is published to ruby-gems.
+gem 'hyrax-preservation', github: 'IUBLibTech/hyrax-preservation', branch: 'namesapec_under_hyrax'

--- a/hyrax-ingest.gemspec
+++ b/hyrax-ingest.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |s|
   s.add_dependency "hyrax", "~> 1.0.3"
   s.add_dependency "minitar"
   s.add_dependency "nokogiri"
+  s.add_dependency 'hyrax-preservation'
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "rspec"

--- a/lib/hyrax/ingest/errors.rb
+++ b/lib/hyrax/ingest/errors.rb
@@ -18,8 +18,8 @@ module Hyrax
       end
 
       class InvalidSIP < Hyrax::Ingest::Error
-        def initialize(fetcher_obj, invalid_sip_obj)
-          super("Invalid SIP object. SIP must be an instance of Hyrax::Ingest::SIP (or an instance of a subclass) but an instance of #{invalid_sip_obj.class} was found. Set a valid SIP object with #{fetcher_obj.class}#sip=")
+        def initialize(invalid_sip_obj)
+          super("Invalid SIP object. SIP must be an instance of Hyrax::Ingest::SIP (or an instance of a subclass) but an instance of #{invalid_sip_obj.class} was found.")
         end
       end
 

--- a/lib/hyrax/ingest/fetcher.rb
+++ b/lib/hyrax/ingest/fetcher.rb
@@ -2,6 +2,8 @@ require 'hyrax/ingest/mapping'
 require 'hyrax/ingest/fetcher/xml_file'
 require 'hyrax/ingest/fetcher/yaml_file'
 require 'hyrax/ingest/fetcher/literal'
+require 'hyrax/ingest/fetcher/premis_event_type'
+require 'hyrax/ingest/fetcher/rdf_uri'
 require 'hyrax/ingest/errors'
 
 module Hyrax
@@ -14,6 +16,8 @@ module Hyrax
             all_classes << Hyrax::Ingest::Fetcher::XMLFile
             all_classes << Hyrax::Ingest::Fetcher::YAMLFile
             all_classes << Hyrax::Ingest::Fetcher::Literal
+            all_classes << Hyrax::Ingest::Fetcher::PremisEventType
+            all_classes << Hyrax::Ingest::Fetcher::RdfUri
           end
         end
 

--- a/lib/hyrax/ingest/fetcher/base.rb
+++ b/lib/hyrax/ingest/fetcher/base.rb
@@ -8,7 +8,7 @@ module Hyrax
         attr_reader :sip
 
         def initialize(sip)
-          raise Hyrax::Ingest::Errors::InvalidSIP.new(self, sip) unless sip.is_a? Hyrax::Ingest::SIP
+          raise Hyrax::Ingest::Errors::InvalidSIP.new(sip) unless sip.is_a? Hyrax::Ingest::SIP
           @sip = sip
         end
 

--- a/lib/hyrax/ingest/fetcher/literal.rb
+++ b/lib/hyrax/ingest/fetcher/literal.rb
@@ -11,9 +11,7 @@ module Hyrax
           @literal_value = literal_value
           super(sip)
         end
-
-        # No-op method intended to be overwritten in subclasses.
-        # @return nil
+        
         def fetch
           literal_value
         end

--- a/lib/hyrax/ingest/fetcher/premis_event_type.rb
+++ b/lib/hyrax/ingest/fetcher/premis_event_type.rb
@@ -1,0 +1,25 @@
+# This class adhere's to the Hyrax::Ingest::Fetcher::Base interface to work other classes within the Hyrax::Ingest
+# gem. If effectively maps PREMIS Event Type abbreviations to the URI that is then associated with a
+# Hyrax::Preservation::Event model.
+
+require 'hyrax/ingest/errors'
+require 'hyrax/ingest/sip'
+
+module Hyrax
+  module Ingest
+    module Fetcher
+      class PremisEventType < Base
+        attr_reader :abbr
+
+        def initialize(sip, abbr='')
+          @abbr = abbr
+          super(sip)
+        end
+
+        def fetch
+          Hyrax::Preservation::PremisEventType.find_by_abbr(@abbr).uri
+        end
+      end
+    end
+  end
+end

--- a/lib/hyrax/ingest/fetcher/rdf_uri.rb
+++ b/lib/hyrax/ingest/fetcher/rdf_uri.rb
@@ -1,0 +1,20 @@
+require 'rdf'
+
+module Hyrax
+  module Ingest
+    module Fetcher
+      class RdfUri < Base
+        attr_reader :uri_str
+
+        def initialize(sip, uri_str='')
+          @uri_str = uri_str
+          super(sip)
+        end
+
+        def fetch
+          ::RDF::URI.new(uri_str)
+        end
+      end
+    end
+  end
+end

--- a/lib/hyrax/ingest/ingester.rb
+++ b/lib/hyrax/ingest/ingester.rb
@@ -4,6 +4,7 @@
 require 'hyrax/ingest/ingester/active_fedora_base_ingester'
 require 'hyrax/ingest/ingester/file_set_ingester'
 require 'hyrax/ingest/ingester/work_ingester'
+require 'hyrax/ingest/ingester/preservation_event_ingester'
 require 'hyrax/ingest/errors'
 
 module Hyrax
@@ -16,6 +17,7 @@ module Hyrax
             registered_classes << Hyrax::Ingest::Ingester::ActiveFedoraBaseIngester
             registered_classes << Hyrax::Ingest::Ingester::FileSetIngester
             registered_classes << Hyrax::Ingest::Ingester::WorkIngester
+            registered_classes << Hyrax::Ingest::Ingester::PreservationEventIngester
           end
         end
 

--- a/lib/hyrax/ingest/ingester/base.rb
+++ b/lib/hyrax/ingest/ingester/base.rb
@@ -4,6 +4,7 @@ module Hyrax
       class Base
         attr_reader :sip
         def initialize(sip)
+          raise Hyrax::Ingest::Errors::InvalidSIP.new(sip) unless sip.is_a? Hyrax::Ingest::SIP
           @sip = sip
         end
 

--- a/lib/hyrax/ingest/ingester/file_set_ingester.rb
+++ b/lib/hyrax/ingest/ingester/file_set_ingester.rb
@@ -5,10 +5,11 @@ module Hyrax
   module Ingest
     module Ingester
       class FileSetIngester < ActiveFedoraBaseIngester
-        attr_reader :files_config
+        attr_reader :files_config, :preservation_events_config
 
         def initialize(sip, config={})
           @files_config = config.delete(:Files) || []
+          @preservation_events_config = config.delete(:PreservationEvents) || []
           config[:af_model_class_name] ||= 'FileSet'
           super(sip, config)
         end
@@ -16,6 +17,7 @@ module Hyrax
         def run!
           assign_properties!
           af_model.save!
+          ingest_preservation_events!
           add_files_to_file_set!
         end
 
@@ -34,6 +36,19 @@ module Hyrax
           def file_ingesters
             @file_ingesters ||= files_config.map do |file_config|
               Hyrax::Ingest::Ingester::ActiveFedoraFileIngester.new(file_config)
+            end
+          end
+
+          def ingest_preservation_events!
+            preservation_event_ingesters.each do |preservation_event_ingester|
+              preservation_event_ingester.run!
+            end
+          end
+
+          def preservation_event_ingesters
+            preservation_event_ingesters ||= preservation_events_config.map do |preservation_event_config|
+              preservation_event_config[:premis_event_related_object] = af_model
+              Hyrax::Ingest::Ingester::PreservationEventIngester.new(sip, preservation_event_config)
             end
           end
       end

--- a/lib/hyrax/ingest/ingester/preservation_event_ingester.rb
+++ b/lib/hyrax/ingest/ingester/preservation_event_ingester.rb
@@ -1,0 +1,25 @@
+require 'hyrax/ingest/ingester/active_fedora_base_ingester'
+require 'hyrax/ingest/ingester/active_fedora_file_ingester'
+
+module Hyrax
+  module Ingest
+    module Ingester
+      class PreservationEventIngester < ActiveFedoraBaseIngester
+
+        attr_reader :premis_event_related_object
+
+        def initialize(sip, config={})
+          config[:af_model_class_name] ||= 'Hyrax::Preservation::Event'
+          @premis_event_related_object = config.delete(:premis_event_related_object)
+          super(sip, config)
+        end
+
+        def run!
+          assign_properties!
+          af_model.premis_event_related_object = premis_event_related_object
+          af_model.save!
+        end
+      end
+    end
+  end
+end

--- a/spec/features/ingest_file_set_with_preservation_events_spec.rb
+++ b/spec/features/ingest_file_set_with_preservation_events_spec.rb
@@ -1,0 +1,37 @@
+require 'hyrax_helper'
+require 'hyrax/ingest/runner'
+require 'file_set'
+
+RSpec.describe "Ingesting a FileSet with Preservation Events" do
+
+  before do
+    @runner = Hyrax::Ingest::Runner.new(
+      config_file_path: "#{fixture_path}/ingest_config_examples/ingest_file_set_with_preservation_events.yml",
+      # dummy path required until it's optional.
+      source_files_path: "#{fixture_path}"
+    )
+
+    @runner.run!
+  end
+
+  context "with config from ingest_file_set_with_preservation_events.yml" do
+
+    let(:preservation_events) { Hyrax::Preservation::Event.all }
+    let(:file_sets) { ::FileSet.all }
+
+    it "does not have any errors" do
+      expect(@runner.errors).to be_empty
+    end
+
+    it 'ingests the correctd number of records' do
+      expect(preservation_events.count).to eq 1
+      expect(file_sets.count).to eq 1
+    end
+
+    it 'ingests the Preservation Events that are associated with the FileSet' do
+      preservation_events.each do |preservation_event|
+        expect(preservation_event.premis_event_related_object).to eq file_sets.first
+      end
+    end
+  end
+end

--- a/spec/features/ingest_preservation_event_spec.rb
+++ b/spec/features/ingest_preservation_event_spec.rb
@@ -1,0 +1,37 @@
+require 'hyrax_helper'
+require 'hyrax/ingest/runner'
+# require 'hyrax/preservation/event'
+
+RSpec.describe "Ingesting a Hyrax::Preservation::Event" do
+  before do
+    @runner = Hyrax::Ingest::Runner.new(
+      config_file_path: "#{fixture_path}/ingest_config_examples/ingest_preservation_event.yml",
+      # dummy path required until path is made optional.
+      source_files_path: "#{fixture_path}"
+    )
+
+    @runner.run!
+  end
+
+  context "with config from ingest_preservation_event.yml" do
+
+    let(:all_preservation_events) { Hyrax::Preservation::Event.all }
+    let(:preservation_event) { all_preservation_events.first }
+
+    it "does not have any errors" do
+      expect(@runner.errors).to be_empty
+    end
+
+    it 'ingests the correct number of Hyrax::Preservation::Event models' do
+      expect(all_preservation_events.count).to eq 1
+    end
+
+    it 'ingests the PREMIS Event Type' do
+      expect(preservation_event.premis_event_type.first.to_uri.to_s).to eq 'http://id.loc.gov/vocabulary/preservation/eventType/ing'
+    end
+
+    it 'ingests the PREMIS agent' do
+      expect(preservation_event.premis_agent.first.to_uri.to_s).to eq 'mailto:admin@example.org'
+    end
+  end
+end

--- a/spec/fixtures/ingest_config_examples/ingest_file_set_with_preservation_events.yml
+++ b/spec/fixtures/ingest_config_examples/ingest_file_set_with_preservation_events.yml
@@ -1,0 +1,17 @@
+---
+ingest:
+  - FileSet:
+      properties:
+        - rdf_predicate: http://purl.org/dc/terms/title
+          from:
+            XMLFile:
+              filename: example_fits.xml
+              xpath: /fits/fileinfo/filename
+      PreservationEvents:
+        - properties:
+          - rdf_predicate: "http://www.loc.gov/premis/rdf/v1#hasEventType"
+            from:
+              PremisEventType: 'ing'
+          - rdf_predicate: "http://www.loc.gov/premis/rdf/v1#hasAgent"
+            from:
+              RdfUri: 'mailto:admin@example.org'

--- a/spec/fixtures/ingest_config_examples/ingest_preservation_event.yml
+++ b/spec/fixtures/ingest_config_examples/ingest_preservation_event.yml
@@ -1,0 +1,10 @@
+---
+ingest:
+  - PreservationEvent:
+      properties:
+      - rdf_predicate: "http://www.loc.gov/premis/rdf/v1#hasEventType"
+        from:
+          PremisEventType: 'ing'
+      - rdf_predicate: "http://www.loc.gov/premis/rdf/v1#hasAgent"
+        from:
+          RdfUri: 'mailto:admin@example.org'

--- a/spec/hyrax/ingest/ingester/preservation_event_ingester_spec.rb
+++ b/spec/hyrax/ingest/ingester/preservation_event_ingester_spec.rb
@@ -1,18 +1,16 @@
 require 'hyrax_helper'
-require 'hyrax/ingest/ingester/file_set_ingester'
+require 'hyrax/ingest/ingester/preservation_event_ingester'
 
-RSpec.describe Hyrax::Ingest::Ingester::FileSetIngester do
+RSpec.describe Hyrax::Ingest::Ingester::PreservationEventIngester do
   describe '#run!' do
     let(:example_sip) { Hyrax::Ingest::SIP.new(path: fixture_path) }
     let(:example_config) { { 'Files' => {}, 'properties' => {} } }
 
     subject { described_class.new(example_sip, example_config) }
 
-    it 'calls assign_properties!, af_model.save!, and add_files_to_file_set! in order' do
+    it 'calls af_model.save!' do
       expect(subject).to receive(:assign_properties!).ordered.exactly(1).times
       expect(subject.af_model).to receive(:save!).ordered.exactly(1).times
-      expect(subject).to receive(:add_files_to_file_set!).ordered.exactly(1).times
-
       subject.run!
     end
   end

--- a/spec/test_app_templates/Gemfile.extra
+++ b/spec/test_app_templates/Gemfile.extra
@@ -1,0 +1,2 @@
+# TODO: Need to pull from github until gem is published to ruby-gems.
+gem 'hyrax-preservation', github: 'IUBLibTech/hyrax-preservation', branch: 'namesapec_under_hyrax'


### PR DESCRIPTION
* Adds hyrax-preservation gem (currently pinned to github branch).
* Adds fetcher class for RdfUri, which will basically wrap a string from
  ingest configuraiton YAML in a RDF::URI object.
* Adds fetcher class for PremisEventType, which maps the abbreviation of
  PREMIS event types to their corresponding URI using the
  Hyrax::Preservation::PremisEventType model.
* Adds ability to ingest Preservation Events associated with FileSets.
* Modify InvalidSIP error to not depend on Fetcher class
* Modifies FileSetIngester spec