### PR TITLE
Closes files within a SIP after a Runner ingests them

### DIFF
--- a/lib/hyrax/ingest/runner.rb
+++ b/lib/hyrax/ingest/runner.rb
@@ -14,6 +14,7 @@ module Hyrax
 
       def run!
         ingesters.collect { |ingester| ingester.run! }
+        sip.close_all_files
       end
 
       def errors

--- a/lib/hyrax/ingest/sip.rb
+++ b/lib/hyrax/ingest/sip.rb
@@ -23,6 +23,11 @@ module Hyrax
         @files ||= []
       end
 
+      def close_all_files
+        files.each { |f| f.close }
+        @files = nil
+      end
+
       private
 
         # @return Array An Array containing the one and only file pointed to by #path


### PR DESCRIPTION
This came about because of a 'too many open files' error when trying to run an
ingets of 143 SIPs from a Rails console.