### PR TITLE
Tweaks ingest rake task

### DIFF
--- a/.solr_wrapper.development.yml
+++ b/.solr_wrapper.development.yml
@@ -2,6 +2,7 @@
 instance_dir: tmp/solr-development
 port: 8983
 verbose: true
+version: 6.6.1
 collection:
   dir: spec/support/solr/config
   persist: true

--- a/.solr_wrapper.test.yml
+++ b/.solr_wrapper.test.yml
@@ -1,6 +1,7 @@
 # Default configuration for solr_wrapper in test environment
 instance_dir: tmp/solr-test
 port: 8985
+version: 6.6.1
 collection:
   dir: spec/support/solr/config
   name: hydra-test

--- a/lib/tasks/ingest_tasks.rake
+++ b/lib/tasks/ingest_tasks.rake
@@ -1,24 +1,21 @@
-require 'hyrax/ingest/runner'
+require 'hyrax/ingest/batch_runner'
 require 'rails'
 
 namespace :hyrax do
   desc 'Ingest one or more SIPs, using a specified package configuration'
-  task :ingest, [:package_type] => :environment do |_task, args|
-    package_types = {}
-    Dir[Rails.root.join('config', 'ingests', '*.yml')].each do |path|
-      package_types[File.basename(path, File.extname(path))] = path
-    end
-    package_config = package_types[args.package_type]
-    abort "Invalid package_type: #{args.package_type}.  Valid package types: #{package_types.keys.join(', ')}" unless package_config
+  task :ingest => :environment do
+    config_file_path = ENV['config_file_path']
+    # Globbed paths represent batches, so expand them and add to the list of sip_paths.
+    sip_paths = ENV['sip_paths'].to_s.split(',').map! do |sip_path|
+      batch = Dir.glob(sip_path)
+      batch.empty? ? sip_path : batch
+    end.flatten
 
-    sip_paths = ARGV[1..-1]
-    abort 'usage: rake hyrax:ingest[package_type] /path/to/sip...' if sip_paths.none?
-    sip_paths.each do |sip_path|
-      @runner = Hyrax::Ingest::Runner.new(
-        config_file_path: package_config,
-        source_files_path: sip_path
-      )
-      @runner.run!
+    if !config_file_path || sip_paths.empty?
+      abort "Error: Invalid Parameters\n\nUsage: rake hyrax:ingest config_file=FILE sip_paths=DIR[,DIR,...]\n\n"
     end
+
+    batch_runner = Hyrax::Ingest::BatchRunner.new(config_file_path: config_file_path, sip_paths: sip_paths)
+    batch_runner.run!
   end
 end


### PR DESCRIPTION
* Uses ENV vars for more flexibility, and less potential conflict with rake
  flags.
* Combines batch ingest with single SIP ingest, allowing globs to be passed as
  SIP paths.