### PR TITLE
Refactors of Reporting module, and more

### DIFF
--- a/lib/hyrax/ingest/errors.rb
+++ b/lib/hyrax/ingest/errors.rb
@@ -132,6 +132,18 @@ module Hyrax
           super("Unknown transform option: '#{unrecognized_transform_option}'")
         end
       end
+
+      class UnableToPrintIngestReport < Hyrax::Ingest::Error
+        def initialize(unable_to_read_from_this_thing)
+          super("Cannot print ingest report from #{unable_to_read_from_this_thing}. To print a report, it must be written to a file.")
+        end
+      end
+
+      class InvalidReportConfigOptions < Hyrax::Ingest::Error
+        def initialize(invalid_options)
+          super("Invalid reporting config options: #{invalid_options.join(', ')}")
+        end
+      end
     end
   end
 end

--- a/lib/hyrax/ingest/ingester/active_fedora_property_assigner.rb
+++ b/lib/hyrax/ingest/ingester/active_fedora_property_assigner.rb
@@ -8,7 +8,6 @@ module Hyrax
     module Ingester
       class ActiveFedoraPropertyAssigner
         include Reporting
-
         attr_reader :rdf_predicate, :af_model, :fetcher, :transformer
 
         def initialize(options={})
@@ -25,6 +24,9 @@ module Hyrax
           fetched_value = transformer.transform(fetched_value) if transformer
           report.value_assigned_to_property(fetched_value, property_name, rdf_predicate)
           af_model.set_value(property_name, fetched_value)
+        rescue ::ActiveTriples::Relation::ValueError => e
+          # Rethrow ActiveTriples::Relation::ValueError as something more specific to ingest.
+          raise Hyrax::Ingest::Errors::InvalidActiveFedoraPropertyValue.new(fetched_value, property_name, rdf_predicate)
         end
 
         private

--- a/lib/hyrax/ingest/ingester/base.rb
+++ b/lib/hyrax/ingest/ingester/base.rb
@@ -12,9 +12,8 @@ module Hyrax
           @sip = sip
         end
 
-        def run!
-          # no-op, meant to be overrriden
-        end
+        # no-op, meant to be overrriden
+        def run!; end
       end
     end
   end

--- a/lib/hyrax/ingest/ingester/file_set_ingester.rb
+++ b/lib/hyrax/ingest/ingester/file_set_ingester.rb
@@ -16,9 +16,10 @@ module Hyrax
 
         def run!
           assign_properties!
-          af_model.save!
+          save_model!
           ingest_preservation_events!
           add_files_to_file_set!
+          # return the new instance of the ActiveFedora model
           af_model
         end
 

--- a/lib/hyrax/ingest/ingester/preservation_event_ingester.rb
+++ b/lib/hyrax/ingest/ingester/preservation_event_ingester.rb
@@ -17,7 +17,9 @@ module Hyrax
         def run!
           assign_properties!
           af_model.premis_event_related_object = premis_event_related_object
-          af_model.save!
+          save_model!
+          # return the new instance of the ActiveFedora model
+          af_model
         end
       end
     end

--- a/lib/hyrax/ingest/ingester/work_ingester.rb
+++ b/lib/hyrax/ingest/ingester/work_ingester.rb
@@ -16,13 +16,18 @@ module Hyrax
 
         def run!
           assign_properties!
-          file_set_ingesters.each { |file_set_ingester| file_set_ingester.assign_properties! }
-          af_model.save!
+          assign_related_file_set_properties!
+          save_model!
           assign_file_sets_to_work!
+          # return the new instance of the ActiveFedora model
           af_model
         end
 
         private
+
+          def assign_related_file_set_properties!
+            file_set_ingesters.each { |file_set_ingester| file_set_ingester.assign_properties! }
+          end
 
           def assign_file_sets_to_work!
             file_set_ingesters.each do |file_set_ingester|

--- a/lib/hyrax/ingest/reporting.rb
+++ b/lib/hyrax/ingest/reporting.rb
@@ -6,67 +6,102 @@ module Hyrax
 
     module Reporting
       def report
-        @reporter ||= Hyrax::Ingest::SharedReporter.instance
+        @report ||= Hyrax::Ingest::SharedReport.instance
+      end
+
+      def print_report
+        report.print_report
       end
 
       def self.config
-        @config ||= {
-          write_to: STDOUT,
+        Hyrax::Ingest::SharedReport.instance.config
+      end
+
+      def self.config=(config)
+        Hyrax::Ingest::SharedReport.instance.config = config
+      end
+    end
+
+    class SharedReport
+      include Singleton
+
+      attr_reader :config
+
+      def initialize
+        @summary = {}
+        @config = default_config
+      end
+
+      def config=(config)
+        validate_config!(config)
+        @config = config
+      end
+
+      def default_config
+        {
+          filename: 'hyrax_ingest_report.log',
+          append: false,
           verbose: true,
           summarize: true
         }
       end
-    end
 
-    class SharedReporter
-      include Singleton
-
-      attr_reader :logger
-
-      def initialize
-        @logger = Logger.new(Reporting.config[:write_to]).tap do |logger|
-          # Simplify the formatter to just put the message.
-          logger.formatter = -> severity,datetime,progname,msg { "\n#{msg}" }
-        end
-
-        @summary = {}
+      def print_report
+        File.read(config[:filename])
       end
 
       def verbose?
-        !!Reporting.config[:verbose]
+        !!config[:verbose]
       end
 
       def summarize?
-        verbose? || !!Reporting.config[:summarize]
+        verbose? || !!config[:summarize]
+      end
+
+      def write(text)
+        File.open(config[:filename], 'a') { |f| f.write(text) }
       end
 
       def batch_ingest_started(num_sips)
-        logger.info "Batch ingest started: ingesting #{num_sips} SIPs." if summarize?
+        write "Batch ingest started: ingesting #{num_sips} SIPs." if summarize?
       end
 
       def batch_ingest_complete(num_sips)
-        logger.info "Batch ingest complete: #{num_sips} SIPs ingested." if summarize?
+        write "Batch ingest complete: #{num_sips} SIPs ingested." if summarize?
       end
 
       def sip_ingest_started(iteration, total_count)
-        logger.info "SIP #{iteration} of #{total_count} ingest started."
+        write "SIP #{iteration} of #{total_count} ingest started."
       end
 
       def sip_ingest_complete(iteration, total_count)
-        logger.info "SIP #{iteration} of #{total_count} ingest complete."
+        write "SIP #{iteration} of #{total_count} ingest complete."
       end
 
       def model_ingest_started(model_name)
-        logger.info "Ingest of #{model_name} started." if verbose?
+        write "Ingest of #{model_name} started." if verbose?
       end
 
       def model_ingest_complete(model_name)
-        logger.info "Ingest of #{model_name} complete" if verbose?
+        write "Ingest of #{model_name} complete" if verbose?
+      end
+
+      def model_ingest_failed_validation(model_name, validation_error_message)
+        write "Ingest of #{model_name} failed. #{validation_error_message}"
       end
 
       def value_assigned_to_property(value, property_name, rdf_predicate)
-         logger.info "value: '#{value}'\nproperty: #{property_name}\npredicate: #{rdf_predicate}\n" if verbose?
+         write "value: '#{value}'\nproperty: #{property_name}\npredicate: #{rdf_predicate}\n" if verbose?
       end
+
+      private
+
+        def validate_config!(config)
+          raise ArgumentError, 'Reporting config must be a hash' unless config.is_a? Hash
+          invalid_options = config.keys - default_config.keys
+          raise Hyrax::Ingest::Errors::InvalidReportingConfigOption(invalid_options) unless invalid_options.empty?
+          true
+        end
     end
   end
 end

--- a/lib/hyrax/ingest/runner.rb
+++ b/lib/hyrax/ingest/runner.rb
@@ -1,10 +1,13 @@
 require 'hyrax/ingest/configuration'
 require 'hyrax/ingest/ingester'
+require 'hyrax/ingest/reporting'
 
 
 module Hyrax
   module Ingest
     class Runner
+      include Reporting
+
       attr_reader :config, :sip
 
       def initialize(config_file_path:, source_files_path:)

--- a/spec/features/ingest_active_fedora_model_from_xml_spec.rb
+++ b/spec/features/ingest_active_fedora_model_from_xml_spec.rb
@@ -17,9 +17,6 @@ RSpec.describe "Ingesting an ActiveFedora model from XML" do
       source_files_path: "#{fixture_path}/sip_examples/ingest_active_fedora_model_from_xml"
     )
 
-    # TODO: Replace this before hook with ActiveFedora cleaner
-    ActiveFedora::Base.all.each { |af| af.delete }
-
     @runner.run!
   end
 
@@ -35,9 +32,6 @@ RSpec.describe "Ingesting an ActiveFedora model from XML" do
   end
 
   after do
-    # TODO: Replace this before hook with ActiveFedora cleaner
-    ActiveFedora::Base.all.each { |af| af.delete }
-
     Object.send(:remove_const, :MyModel)
   end
 end

--- a/spec/features/ingest_af_model_with_missing_metadata_spec.rb
+++ b/spec/features/ingest_af_model_with_missing_metadata_spec.rb
@@ -1,0 +1,36 @@
+require 'hyrax_helper'
+require 'hyrax/ingest/runner'
+
+RSpec.describe "Ingesting an ActiveFedora model with missing metadata" do
+
+  before do
+    class MyModel < ActiveFedora::Base
+      property :title, predicate: 'http://example.org#title' do |index|
+        index.as :stored_searchable
+      end
+
+      validates :title, presence: true
+    end
+  end
+
+  let(:config_file_path) { "#{fixture_path}/ingest_config_examples/ingest_af_model_with_missing_metadata.yml" }
+  # Set a dummy source_files_path that we won't use.
+  let(:source_files_path) { fixture_path }
+  let(:runner) { Hyrax::Ingest::Runner.new(config_file_path: config_file_path, source_files_path: source_files_path) }
+
+  context "with config from ingest_af_model_with_missing_metadata.yml" do
+    before { runner.run! }
+
+    it 'logs it as an error' do
+      # TODO: making this test less brittle by not hardcoding the expected message.
+      expect(runner.print_report).to include("Ingest of MyModel failed. Validation failed: Title can't be blank")
+    end
+
+    it 'does not ingest the object' do
+      search_results = MyModel.all
+      expect(search_results).to be_empty
+    end
+  end
+
+  after { Object.send(:remove_const, :MyModel) }
+end

--- a/spec/fixtures/ingest_config_examples/ingest_af_model_with_missing_metadata.yml
+++ b/spec/fixtures/ingest_config_examples/ingest_af_model_with_missing_metadata.yml
@@ -1,0 +1,8 @@
+---
+ingest:
+  - ActiveFedoraBase:
+      af_model_class_name: MyModel
+      properties:
+        - rdf_predicate: http://example.org#title
+          from:
+            Literal: # intentionally no value here

--- a/spec/hyrax/ingest/ingester/file_set_ingester_spec.rb
+++ b/spec/hyrax/ingest/ingester/file_set_ingester_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Hyrax::Ingest::Ingester::FileSetIngester do
 
     it 'calls assign_properties!, af_model.save!, and add_files_to_file_set! in order' do
       expect(subject).to receive(:assign_properties!).ordered.exactly(1).times
-      expect(subject.af_model).to receive(:save!).ordered.exactly(1).times
+      expect(subject).to receive(:save_model!).ordered.exactly(1).times
       expect(subject).to receive(:add_files_to_file_set!).ordered.exactly(1).times
 
       subject.run!

--- a/spec/hyrax/ingest/ingester/preservation_event_ingester_spec.rb
+++ b/spec/hyrax/ingest/ingester/preservation_event_ingester_spec.rb
@@ -8,9 +8,9 @@ RSpec.describe Hyrax::Ingest::Ingester::PreservationEventIngester do
 
     subject { described_class.new(example_sip, example_config) }
 
-    it 'calls af_model.save!' do
+    it 'calls save_model!' do
       expect(subject).to receive(:assign_properties!).ordered.exactly(1).times
-      expect(subject.af_model).to receive(:save!).ordered.exactly(1).times
+      expect(subject).to receive(:save_model!).ordered.exactly(1).times
       subject.run!
     end
   end

--- a/spec/hyrax/ingest/ingester/work_ingester_spec.rb
+++ b/spec/hyrax/ingest/ingester/work_ingester_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Hyrax::Ingest::Ingester::WorkIngester do
 
     it 'calls assign_properties!' do
       expect(subject).to receive(:assign_properties!).ordered.exactly(1).times
-      expect(subject.af_model).to receive(:save!).ordered.exactly(1).times
+      expect(subject).to receive(:save_model!).ordered.exactly(1).times
       expect(subject).to receive(:assign_file_sets_to_work!).ordered.exactly(1).times
 
       subject.run!

--- a/spec/hyrax/ingest/reporting_spec.rb
+++ b/spec/hyrax/ingest/reporting_spec.rb
@@ -9,7 +9,7 @@ describe Hyrax::Ingest::Reporting do
 
   describe '#report' do
     it 'returns a SharedReporter object' do
-      expect(TestClass1.new.report).to be_a Hyrax::Ingest::SharedReporter
+      expect(TestClass1.new.report).to be_a Hyrax::Ingest::SharedReport
     end
 
     it 'returns the same (singleton) Logger object when included in 2 different classes' do
@@ -21,3 +21,19 @@ describe Hyrax::Ingest::Reporting do
   after { [:TestClass1, :TestClass2].each { |sym| Object.send(:remove_const, sym) } }
 end
 
+
+
+describe Hyrax::Ingest::SharedReport do
+  describe 'write' do
+
+    let(:report) { Hyrax::Ingest::SharedReport.instance }
+    let(:report_output) { report.print_report }
+    let(:test_text) { "this is some test text" }
+
+    before { report.write(test_text) }
+
+    it 'writes text to the report' do
+      expect(report_output).to include test_text
+    end
+  end
+end

--- a/spec/hyrax_helper.rb
+++ b/spec/hyrax_helper.rb
@@ -17,4 +17,8 @@ RSpec.configure do |config|
     require 'active_fedora/cleaner'
     ActiveFedora::Cleaner.clean! if ActiveFedora::Base.count > 0
   end
+
+  config.after(:suite) do
+    File.delete(Hyrax::Ingest::Reporting.config[:filename]) if File.exist? Hyrax::Ingest::Reporting.config[:filename]
+  end
 end


### PR DESCRIPTION
* Logs failed ingest of individual models. Instead of failing a whole ingest due
  to missing required metadata, log the error and continue the ingest without
  saving the invalid model.
* Removes dependency on Logger instance. Initially thought it would be
  convenient to leverage Logger, but there isn't much to be gained, and there
  were some I/O issues to work around.
* Rethrows an ActiveTriples error to something more relevant to ingest.
* Allows setting config for ingest reporting.
* Removes redundant AF cleaning in specs.
* Deletes report file after test suite runs.