### PR TITLE
Do not load tasks from ci.rake in host app

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -8,6 +8,6 @@ require "bundler/gem_tasks"
 require "rspec/core/rake_task"
 require 'engine_cart/rake_task'
 
-Dir.glob('lib/tasks/**/*.rake').each { |r| import r }
+Dir.glob('gem_development_tasks/**/*.rake').each { |r| import r }
 
 task :default => :ci

--- a/gem_development_tasks/ci.rake
+++ b/gem_development_tasks/ci.rake
@@ -6,9 +6,9 @@ task :ci => ["engine_cart:generate"] do
   ENV['RAILS_ENV'] = 'test'
   ENV['TRAVIS'] = '1'
 
-  FcrepoWrapper.wrap(config: File.expand_path('../../../.fcrepo_wrapper.test.yml', __FILE__)) do |fc|
-    SolrWrapper.wrap(config: File.expand_path('../../../.solr_wrapper.test.yml', __FILE__)) do |solr|
-      solr.with_collection(name: 'hydra-test', dir: File.expand_path('../../../.internal_test_app/solr/config', __FILE__)) do
+  FcrepoWrapper.wrap(config: File.expand_path('../../.fcrepo_wrapper.test.yml', __FILE__)) do |fc|
+    SolrWrapper.wrap(config: File.expand_path('../../.solr_wrapper.test.yml', __FILE__)) do |solr|
+      solr.with_collection(name: 'hydra-test', dir: File.expand_path('../../.internal_test_app/solr/config', __FILE__)) do
         RSpec::Core::RakeTask.new(:rspec) do |task|
           task.rspec_opts      = ENV['RSPEC_OPTS']            unless ENV['RSPEC_OPTS'].nil?
           task.pattern         = ENV['RSPEC_PATTERN']         unless ENV['RSPEC_PATTERN'].nil?

--- a/hyrax-ingest.gemspec
+++ b/hyrax-ingest.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |s|
   s.description = "Description of Hyrax::Ingest."
   s.license     = "MIT"
 
-  s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
+  s.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "README.md"]
 
   s.add_dependency "rails", "~> 5"
   s.add_dependency "hyrax", "~> 1.0.3"


### PR DESCRIPTION
Railties will automatically load all tasks from an Engine's lib/tasks directory,
so to prevent a host app from loading rake tasks intended for development only,
we move those tasks to a location outside of lib/tasks, in our case, we chose
./gem_development_tasks/.