### PR TITLE
HDM-1164: batch add metadata in ingest task

### DIFF
--- a/lib/hyrax/ingest/fetcher/xml_file.rb
+++ b/lib/hyrax/ingest/fetcher/xml_file.rb
@@ -6,7 +6,7 @@ module Hyrax
   module Ingest
     module Fetcher
       class XMLFile < Base
-        attr_reader :filename, :xpath
+        attr_reader :filename, :xpath, :default
 
         include HasSIP
 
@@ -15,11 +15,15 @@ module Hyrax
           raise ArgumentError, "Required option :xpath is missing" unless options.key?(:xpath)
           @filename = options[:filename]
           @xpath = options[:xpath]
+          @default = options[:default]
         end
 
         def fetch
           # TODO: log a warning in the event of empty results.
-          noko.xpath(xpath).map(&:text)
+          fetched = noko.xpath(xpath).map(&:text)
+          return fetched if fetched.present?
+          return default if default.present?
+          return []
         end
 
         private

--- a/spec/features/ingest_active_fedora_model_from_xml_with_defaults_spec.rb
+++ b/spec/features/ingest_active_fedora_model_from_xml_with_defaults_spec.rb
@@ -1,0 +1,57 @@
+require 'hyrax_helper'
+require 'hyrax/ingest/runner'
+
+RSpec.describe "Ingesting an ActiveFedora model from XML with default values" do
+
+  before do
+    class MyModel < ActiveFedora::Base
+      property :title, predicate: 'http://example.org#title' do |index|
+        index.as :stored_searchable
+      end
+
+      property :description, predicate: 'http://example.org#description'
+    end
+  end
+
+  context "with values supplied in sip" do
+    before do
+      @runner = Hyrax::Ingest::Runner.new(
+        config_file_path: "#{fixture_path}/ingest_config_examples/ingest_active_fedora_model_from_xml_with_defaults.yml",
+        sip_path: "#{fixture_path}/sip_examples/ingest_active_fedora_model_from_xml"
+      )
+
+      @runner.run!
+    end
+
+    it "does not have any errors" do
+      expect(@runner.errors).to be_empty
+    end
+
+    it 'ingests the model with supplied metadata' do
+      expect(MyModel.where(title: "Test Title 1").count).to eq 1
+    end
+  end
+
+  context "with default values assumed" do
+    before do
+      @runner = Hyrax::Ingest::Runner.new(
+        config_file_path: "#{fixture_path}/ingest_config_examples/ingest_active_fedora_model_from_xml_with_defaults.yml",
+        sip_path: "#{fixture_path}/sip_examples/ingest_active_fedora_model_from_xml_with_defaults"
+      )
+
+      @runner.run!
+    end
+
+    it "does not have any errors" do
+      expect(@runner.errors).to be_empty
+    end
+
+    it 'ingests the model with default metadata' do
+      expect(MyModel.where(title: "Default title").count).to eq 1
+    end
+  end
+
+  after do
+    Object.send(:remove_const, :MyModel)
+  end
+end

--- a/spec/fixtures/ingest_config_examples/ingest_active_fedora_model_from_xml_with_defaults.yml
+++ b/spec/fixtures/ingest_config_examples/ingest_active_fedora_model_from_xml_with_defaults.yml
@@ -1,0 +1,16 @@
+---
+ingest:
+  - ActiveFedoraBase:
+      af_model_class_name: MyModel
+      properties:
+        - rdf_predicate: http://example.org#title
+          from:
+            XMLFile:
+              filename: metadata.xml
+              xpath: /path/to/title_1
+              default: ['Default title']
+        - rdf_predicate: http://example.org#description
+          from:
+            XMLFile:
+              filename: metadata.xml
+              xpath: /path/to/description

--- a/spec/fixtures/sip_examples/ingest_active_fedora_model_from_xml_with_defaults/metadata.xml
+++ b/spec/fixtures/sip_examples/ingest_active_fedora_model_from_xml_with_defaults/metadata.xml
@@ -1,0 +1,5 @@
+<path>
+  <to>
+    <description>Test Description</description>
+  </to>
+</path>


### PR DESCRIPTION
Two commits, which are somewhat independent of each *other:
* HDM-1198: adds an optional `default:` value in the XMLFile hash, used if the xpath finds nothing
* HDM-1199: adds the option to specify additional (comma-separated) files to `config_file=`, with subsequent files adding in `default:` values or overriding lookups with `Literal:` values

What I have for 1199 to handle the deep_merge of a mix of Array/Hash structures works, though there's likely a more elegant, less procedural, approach possible.