### PR TITLE
Allows updating ActiveFedora records

### DIFF
--- a/spec/features/update_af_model_by_id_spec.rb
+++ b/spec/features/update_af_model_by_id_spec.rb
@@ -1,0 +1,35 @@
+require 'hyrax_helper'
+require 'hyrax/ingest/runner'
+
+RSpec.describe "Updating an ActiveFedora model" do
+
+  before do
+    class MyModel < ActiveFedora::Base
+      property :title, predicate: 'http://example.org#title'
+    end
+  end
+
+  context "with config from update_af_model_by_id.yml" do
+
+    before do
+      MyModel.new.tap do |model|
+        model.id = '123'
+        model.title += ['orig title']
+        model.save!
+      end
+
+      Hyrax::Ingest::Runner.new(
+        config_file_path: "#{fixture_path}/ingest_config_examples/update_af_model_by_id.yml",
+        source_files_path: "#{fixture_path}/sip_examples/empty_sip"
+      ).run!
+    end
+
+    it 'updates the model' do
+      expect(MyModel.find('123').title.first).to eq 'updated title'
+    end
+  end
+
+  after do
+    Object.send(:remove_const, :MyModel)
+  end
+end

--- a/spec/fixtures/ingest_config_examples/update_af_model_by_id.yml
+++ b/spec/fixtures/ingest_config_examples/update_af_model_by_id.yml
@@ -1,0 +1,12 @@
+---
+ingest:
+  - ActiveFedoraBase:
+      af_model_class_name: MyModel
+      update:
+        id:
+          from:
+            Literal: 123
+      properties:
+        - rdf_predicate: http://example.org#title
+          from:
+            Literal: 'updated title'


### PR DESCRIPTION
Use update: key for specifying an ActiveFedora where clause with which to find
existing records for updating.

Example:

	---
	ingest:
	  - ActiveFedoraBase:
		  af_model_class_name: MyModel
		  update:
			id:
			  from:
				Literal: 123

Toward HDM-1170