### PR TITLE
Several changes needed by Phydo. See HDM-1241.

### DIFF
--- a/lib/hyrax/ingest/configuration.rb
+++ b/lib/hyrax/ingest/configuration.rb
@@ -31,16 +31,23 @@ module Hyrax
         def validate!
           validate_top_level_key!
           validate_ingester_configs_array!
+          validate_ingester_config_hashes!
         end
 
         # @raise [Hyrax::Ingest::Errors::InvalidConfig] When the top level
         #   'ingest' key is missing.
         def validate_top_level_key!
-          raise Hyrax::Ingest::Errors::InvalidConfig.new("Top-level key 'ingest' is missing.") unless config[:ingest]
+          raise Hyrax::Ingest::Errors::InvalidConfig.new(config_file_path, "Top-level key 'ingest' is missing.") unless config[:ingest]
         end
 
         def validate_ingester_configs_array!
-          raise Hyrax::Ingest::Errors::InvalidConfig.new("Value under top-level 'ingest' key must be an array.") unless config[:ingest].respond_to?(:each)
+          raise Hyrax::Ingest::Errors::InvalidConfig.new(config_file_path, "Value under top-level 'ingest' key must be an array containing the configuration for each ingester you want to use.") unless config[:ingest].respond_to?(:each)
+        end
+
+        def validate_ingester_config_hashes!
+          config[:ingest].each do |ingest_config|
+            raise Hyrax::Ingest::Errors::InvalidConfig.new(config_file_path, "Each ingester configuration must be a single key-value pair, where the key is the type of ingester, and the value is a hash containing the configuration for the ingester. But a #{ingester_config.class} was found instead.") unless ingest_config.respond_to? :keys
+          end
         end
     end
   end

--- a/lib/hyrax/ingest/errors.rb
+++ b/lib/hyrax/ingest/errors.rb
@@ -12,8 +12,14 @@ module Hyrax
       end
 
       class NoSIPSpecified < Hyrax::Ingest::Error
-        def initialize(transformer_obj)
-          super("No SIP was specified. Set the sip with #{transformer_obj.class}#sip=")
+        def initialize(obj)
+          super("No SIP was specified.")
+        end
+      end
+
+      class NoSharedSIPSpecified < Hyrax::Ingest::Error
+        def initialize
+          super("No shared SIP was specified.")
         end
       end
 
@@ -30,8 +36,8 @@ module Hyrax
       end
 
       class FileNotFoundInSIP < Hyrax::Ingest::Error
-        def initialize(string_or_regexp)
-          super("No file matching #{string_or_regexp.inspect.to_s} was found in the SIP")
+        def initialize(sip_path, string_or_regexp)
+          super("No file matching #{string_or_regexp.inspect.to_s} was found in the SIP at path '#{sip_path}'")
         end
       end
 
@@ -83,6 +89,12 @@ module Hyrax
         end
       end
 
+      class RecordNotFound < Hyrax::Ingest::Error
+        def initialize(model_class_name, where_clause)
+          super("Record of type '#{model_class_name}' could not be found where #{where_clause}.")
+        end
+      end
+
       class AmbiguousFetchOptions < Hyrax::Ingest::Error
         def initialize(ambiguous_options)
           super("Could not determine which transformer class to use given the following options: #{Array(ambiguous_options).join(', ')}")
@@ -101,7 +113,12 @@ module Hyrax
         end
       end
 
-      class InvalidConfig < Hyrax::Ingest::Error; end
+      class InvalidConfig < Hyrax::Ingest::Error
+        def initialize(config_file_path, msg=nil)
+          message = ["Invalid configuration in '#{config_file_path}'.", msg.to_s].join("\n")
+          super(message)
+        end
+      end
 
       class InvalidIngesterClass < Hyrax::Ingest::Error
         def initialize(invalid_class)

--- a/lib/hyrax/ingest/sip.rb
+++ b/lib/hyrax/ingest/sip.rb
@@ -32,7 +32,7 @@ module Hyrax
       # @return [File] The file from the SIP that matches the param.
       def find_file(filename)
         file = find_file_by_regex(filename) || find_file_by_name(filename)
-        raise Hyrax::Ingest::Errors::FileNotFoundInSIP.new(filename) unless file
+        raise Hyrax::Ingest::Errors::FileNotFoundInSIP.new(path, filename) unless file
         File.new(file.path)
       end
 
@@ -70,13 +70,6 @@ module Hyrax
         def find_file_by_name(filename)
           files.find { |file| File.basename(file) == filename }
         end
-
-        # @param [String, Regexp] str The string to test and see if it is a regex.
-        # @return [Boolean] True param begins and ends in a forward slash.
-        def is_a_regex?(str)
-          filename.to_s[0] == '/' && filename.to_s[-1] == '/'
-        end
-
 
         # @return Array An Array containing the one and only file pointed to by #path
         def single_file

--- a/lib/tasks/ingest_tasks.rake
+++ b/lib/tasks/ingest_tasks.rake
@@ -10,12 +10,13 @@ namespace :hyrax do
       batch = Dir.glob(sip_path)
       batch.empty? ? sip_path : batch
     end.flatten
+    shared_sip_path = ENV['shared_sip_path']
 
-    if !config_file_path || sip_paths.empty?
-      abort "Error: Invalid Parameters\n\nUsage: rake hyrax:ingest config_file=FILE sip_paths=DIR[,DIR,...]\n\n"
+    if !config_file_path || (sip_paths.empty? && !shared_sip_path)
+      abort "Error: Invalid Parameters\n\nUsage: rake hyrax:ingest config_file=FILE [sip_paths=PATH1[,PATH2,...]] [shared_sip_path=SHARED_PATH]\n\n"
     end
 
-    batch_runner = Hyrax::Ingest::BatchRunner.new(config_file_path: config_file_path, sip_paths: sip_paths)
+    batch_runner = Hyrax::Ingest::BatchRunner.new(config_file_path: config_file_path, sip_paths: sip_paths, shared_sip_path: shared_sip_path)
     batch_runner.run!
   end
 end


### PR DESCRIPTION
* Adds methods to return ingested IDs from batch runner.
* Tighter parameter validation for ingest cofiguration.
* More custom errors.
* Raises an error when update config causes 'record not found'.
* Allows shared SIPs to be specified when ingesting from the rake task.