### PR TITLE
Changes SIP to not hold on to open files

### DIFF
--- a/lib/hyrax/ingest/fetcher/csv_file.rb
+++ b/lib/hyrax/ingest/fetcher/csv_file.rb
@@ -32,7 +32,7 @@ module Hyrax
         private
 
           def roo
-            @roo ||= Roo::CSV.new(sip.find_file(filename))
+            @roo ||= Roo::CSV.new(sip.find_file_path(filename))
           end
 
           def cell_value
@@ -43,7 +43,7 @@ module Hyrax
           def column_number
             @column_number ||= column_number_from_header || specific_column_number
             # TODO: custom error
-            raise ArgumentError, "Value for column: option must be a number or the keyword 'next'; #{row} was given." if @column_number.nil?
+            raise ArgumentError, "Value for column: option must be a number or a column header; '#{column}' was given." if @column_number.nil?
             @column_number
           end
 

--- a/lib/hyrax/ingest/runner.rb
+++ b/lib/hyrax/ingest/runner.rb
@@ -25,7 +25,6 @@ module Hyrax
 
       def run!
         ingesters.collect { |ingester| ingester.run! }
-        sip.close_all_files if sip
       end
 
       def errors

--- a/lib/hyrax/ingest/sip.rb
+++ b/lib/hyrax/ingest/sip.rb
@@ -3,7 +3,7 @@ require 'minitar'
 
 module Hyrax
   module Ingest
-    # A model for reading Submission Information Packages (SIPs) from a filesystem.
+    # A model for reading Submission Information Packages (SIPs) from a file_pathsystem.
     #
     # @attr_reader [String] path description of a readonly attribute
     class SIP
@@ -16,36 +16,27 @@ module Hyrax
       end
 
       # @return [Array] A list of File objects that are part of the SIP
-      def files
-        @files ||= single_file
-        @files ||= files_from_dir
-        @files ||= files_from_tarball
-        @files ||= []
-      end
-
-      def close_all_files
-        files.each { |f| f.close }
-        @files = nil
+      def file_paths
+        @file_paths ||= single_file_path
+        @file_paths ||= file_paths_from_dir
+        @file_paths ||= file_paths_from_tarball
+        @file_paths ||= []
       end
 
       # @param [String, Regexp] filename A string, a Regexp, or a string representation of a regex
       # @return [File] The file from the SIP that matches the param.
-      def find_file(filename)
-        file = find_file_by_regex(filename) || find_file_by_name(filename)
-        raise Hyrax::Ingest::Errors::FileNotFoundInSIP.new(path, filename) unless file
-        File.new(file.path)
+      def find_file_path(basename_or_regex)
+        file_path = file_path_from_regex(basename_or_regex) || file_path_from_basename(basename_or_regex)
+        raise Hyrax::Ingest::Errors::FileNotFoundInSIP.new(path, basename_or_regex) unless file_path
+        file_path
       end
 
       # Reads the content of a file from the SIP, and automatically rewinds it
       # so it can be read again.
       # @param [String, Regexp] filename A string, a Regexp, or a string representation of a regex
       # @return [String] The contents of the matched file
-      def read_file(filename)
-        File.read(find_file(filename).path)
-        # file = find_file(filename)
-        # file_contents = file.read
-        # file.rewind
-        # file_contents
+      def read_file(basename_or_regex)
+        File.read(find_file_path(basename_or_regex))
       end
 
       private
@@ -56,33 +47,33 @@ module Hyrax
         # @return [File] The file that matches regex as a regular expression;
         #   nil if no file matches 'regex', or if 'regex' cannot be used as a
         #   regular expression.
-        def find_file_by_regex(regex)
+        def file_path_from_regex(regex)
           # If 'regex' is a string beginning and ending in slash, convert it to
           # a Regexp.
           regex = Regexp.new(regex.to_s[1..-2]) if regex.to_s =~ /^\/.*\/$/
-          files.find { |file| File.basename(file) =~ regex } if regex.is_a? Regexp
+          file_paths.find { |file| File.basename(file) =~ regex } if regex.is_a? Regexp
         end
 
         # @param [String] filename The name of the file within the SIP you want
         #   to return.
         # @return [File] The file that matches the 'filename' parameter; nil if
         #   no file matches the 'filename'.
-        def find_file_by_name(filename)
-          files.find { |file| File.basename(file) == filename }
+        def file_path_from_basename(filename)
+          file_paths.find { |file| File.basename(file) == filename }
         end
 
         # @return Array An Array containing the one and only file pointed to by #path
-        def single_file
-          [File.new(path)] if File.file? path
+        def single_file_path
+          Array(path) if File.file? path
         end
 
-        def files_from_dir
+        def file_paths_from_dir
           if File.directory? path
-            Dir.glob("#{path}/**/*").select { |entry| File.file? entry }.map{ |entry| File.new(entry) }
+            Dir.glob("#{path}/**/*").select { |entry| File.file? entry }
           end
         end
 
-        def files_from_tarball
+        def file_paths_from_tarball
           # TODO: this is the best test I could find for reliably determining
           # whether a file was a TAR archive or not, but it seems finicky, as
           # it probably depends on your operating system, or what kind of tarball

--- a/spec/features/ingest_af_model_from_csv_spec.rb
+++ b/spec/features/ingest_af_model_from_csv_spec.rb
@@ -22,9 +22,6 @@ RSpec.describe "Ingesting an ActiveFedora model from CSV" do
 
 
   context "with config from ingest_active_fedora_model_from_csv.yml" do
-    it "does not have any errors" do
-      expect(@runner.errors).to be_empty
-    end
 
     it 'ingests the model with metadata' do
       expect(MyModel.where(title: "Test Title 1").count).to eq 1

--- a/spec/hyrax/ingest/sip_spec.rb
+++ b/spec/hyrax/ingest/sip_spec.rb
@@ -12,13 +12,12 @@ RSpec.describe Hyrax::Ingest::SIP do
     end
   end
 
-  describe '#files' do
+  describe '#file_paths' do
     subject { described_class.new(path: "#{fixture_path}/sip_examples/fits_example_1.xml")}
     context 'when given a path to a single file' do
       it 'returns a list containing a single File object for the file specified by the path param' do
-        expect(subject.files.count).to eq 1
-        expect(subject.files.first).to be_a File
-        expect(File.basename(subject.files.first)).to eq 'fits_example_1.xml'
+        expect(subject.file_paths.count).to eq 1
+        expect(File.basename(subject.file_paths.first)).to eq 'fits_example_1.xml'
       end
     end
   end
@@ -27,25 +26,20 @@ RSpec.describe Hyrax::Ingest::SIP do
     subject { described_class.new(path: "#{fixture_path}/sip_examples/fits_example_1.xml")}
     context 'when given an exact filename' do
       it 'returns the file' do
-        expect(subject.find_file('fits_example_1.xml')).to be_a File
+        expect(subject.find_file_path('fits_example_1.xml')).to eq "#{fixture_path}/sip_examples/fits_example_1.xml"
       end
     end
 
     context 'when given a regex as a string' do
       it 'returns the file' do
-        expect(subject.find_file('/^fits_/')).to be_a File
+        expect(subject.find_file_path('/^fits_/')).to eq "#{fixture_path}/sip_examples/fits_example_1.xml"
       end
     end
 
-    context 'when given a Regexp object' do
-      it 'returns the file' do
-        expect(subject.find_file(/^fits_/)).to be_a File
-      end
-    end
 
     context "when given a string that doesn't match any filename in the SIP" do
       it 'raises a FileNotFoundInSIP error' do
-        expect { subject.find_file('not in the sip') }.to raise_error Hyrax::Ingest::Errors::FileNotFoundInSIP
+        expect { subject.find_file_path('not in the sip') }.to raise_error Hyrax::Ingest::Errors::FileNotFoundInSIP
       end
     end
   end


### PR DESCRIPTION
Instead, the SIP just stores a list of fully qualified file paths that can
accessed by the file's basename, or a regex.

Also, fixes incorrect error message in CSVFile fetcher.